### PR TITLE
Make MeqTrees Unnecessary Again

### DIFF
--- a/Owlcat/Flagger.py
+++ b/Owlcat/Flagger.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-import Timba.dmi
 import re
 import tempfile
 import os
 from past.builtins import cmp
 from functools import cmp_to_key
 
-from Cattery import Meow
 import Owlcat
-from Cattery.Meow import MSUtils
 from Kittens.utils import verbosity
 try:
     import Purr.Pipe
@@ -19,15 +16,6 @@ except:
     has_purr = False
 
 _gli = None # Meow.MSUtils.find_exec('glish')
-
-# if _gli:
-#     _GLISH = 'glish'
-#     Meow.dprint("Calico flagger: found %s, autoflag should be available" % _gli)
-# else:
-#     _GLISH = None
-#     Meow.dprint("Calico flagger: glish not found, autoflag will not be available")
-
-# _addbitflagcol = Meow.MSUtils.find_exec('addbitflagcol')
 
 
 # Various argument-formatting methods to use with the Flagger.AutoFlagger class

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
 ]
 
 setup(name='owlcat',
-      version='1.6.0',
+      version='1.6.1',
       description='miscellaneous utility scripts for manipulating radio interferometry data',
       author='Oleg Smirnov',
       author_email='Oleg Smirnov <osmirnov@gmail.com>',


### PR DESCRIPTION
Re-removed unnecessary dependency on Timba/Cattery from Flagger.py, which snuck in with the py3 branch.